### PR TITLE
Fixed issue #6

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,10 @@ pub fn run(args: ArgMatches) {
         let filename = filename.to_str().unwrap();
 
         let result = searcher.search_in_file(filename).unwrap_or_else(|error| {
-            eprintln!("{}: {}", filename, error);
-            process::exit(1);
+            if error.kind() != std::io::ErrorKind::NotFound {
+                eprintln!("{}: {}", filename, error);
+            }
+            Vec::new()
         });
 
         if !result.is_empty() {


### PR DESCRIPTION
No longer do broken symbolic links crash scanning.

Second part of the issue, one with cryptic traceback, is still a mystery though.